### PR TITLE
Take the scrolling behaviours to a base class

### DIFF
--- a/steering/TouchGFX/gui/include/gui/common/ListManager.hpp
+++ b/steering/TouchGFX/gui/include/gui/common/ListManager.hpp
@@ -1,0 +1,149 @@
+#ifndef LISTMANAGER_HPP
+#define LISTMANAGER_HPP
+
+#include <cstdint>
+#include <algorithm>
+
+template <typename T>
+class ListManager {
+public:
+  static const uint8_t MAX_ITEMS = 64;
+
+  void setItems(T *items[], uint8_t nItems)
+  {
+    this->nItems = nItems;
+
+    for (uint8_t i = 0; i < nItems; ++i) {
+        this->items[i] = items[i];
+    }
+
+    currentIndex = static_cast<uint8_t>(0);
+    firstTileIndex = static_cast<uint8_t>(0);
+
+    lastTileIndex = static_cast<uint8_t>(
+        std::min(
+            static_cast<int>(nItems) - 1,
+            static_cast<int>(maxTiles) - 1
+        )
+    );
+
+    _updateItemTilesInView();
+    setSelected();
+  }
+
+  void handleButtonDown()
+  {
+    if (!nItems) return;
+
+    currentIndex = static_cast<uint8_t>(
+        std::min(
+            static_cast<int>(currentIndex) + scrollAmount(),
+            static_cast<int>(nItems) - 1
+        )
+    );
+
+    adaptIndexes();
+    _updateItemTilesInView();
+    setSelected();
+  }
+
+  void handleButtonUp()
+  {
+    if (!nItems) return;
+
+    currentIndex = static_cast<uint8_t>(
+        std::max(
+            static_cast<int>(currentIndex) - scrollAmount(),
+            0
+        )
+    );
+
+    adaptIndexes();
+    _updateItemTilesInView();
+    setSelected();
+  }
+
+  virtual void handleButtonConfirm() {}
+  virtual void handleButtonBack() {}
+protected:
+  ListManager(uint8_t maxTiles) : maxTiles(maxTiles) {}
+
+  T *items[MAX_ITEMS];
+  uint8_t nItems;
+
+  uint8_t currentIndex;
+  uint8_t firstTileIndex;
+  uint8_t lastTileIndex;
+
+  virtual void updateItemTilesInView(T *items[], uint8_t nItems);
+  virtual void setSelected();
+
+  virtual int scrollAmount() { return 1; }
+
+private:
+  uint8_t maxTiles;
+
+  void adaptIndexes()
+  {
+    if (!nItems) {
+        firstTileIndex = static_cast<uint8_t>(0);
+        lastTileIndex = static_cast<uint8_t>(0);
+        return;
+    }
+
+    if (currentIndex < firstTileIndex) {
+        firstTileIndex = currentIndex;
+        lastTileIndex = static_cast<uint8_t>(
+            static_cast<int>(firstTileIndex) + static_cast<int>(maxTiles) - 1
+        );
+    } else if (currentIndex > lastTileIndex) {
+        firstTileIndex = static_cast<uint8_t>(
+            static_cast<int>(currentIndex) - static_cast<int>(maxTiles) - 1
+        );
+        lastTileIndex = currentIndex;
+    }
+
+    if (lastTileIndex >= nItems) {
+        lastTileIndex = static_cast<uint8_t>(nItems - 1);
+        firstTileIndex = static_cast<uint8_t>(
+            std::max(
+                0,
+                static_cast<int>(lastTileIndex) - static_cast<int>(maxTiles) - 1
+            )
+        );
+    }
+    if (firstTileIndex < static_cast<uint8_t>(0)) {
+        firstTileIndex = static_cast<uint8_t>(0);
+        lastTileIndex = static_cast<uint8_t>(
+            std::min(
+                static_cast<int>(nItems) - 1,
+                static_cast<int>(maxTiles) - 1
+            )
+        );
+    }
+  }
+  
+  void _updateItemTilesInView()
+  {
+    uint8_t actualFirst = static_cast<uint8_t>(
+        std::max(0, static_cast<int>(firstTileIndex))
+    );
+    uint8_t actualLast = static_cast<uint8_t>(
+        std::min(
+            static_cast<int>(nItems) - 1,
+            static_cast<int>(lastTileIndex)
+        )
+    );
+
+    T *arrayToPass[static_cast<size_t>(actualLast - actualFirst + 1)];
+    if (actualFirst <= actualLast && nItems > 0) {
+        for (uint8_t i = actualFirst; i <= actualLast; ++i) {
+            arrayToPass[i - actualFirst] = items[i];
+        }
+    }
+
+    updateItemTilesInView(arrayToPass, static_cast<uint8_t>(actualLast - actualFirst + 1));
+  }
+};
+
+#endif // LISTMANAGER_HPP

--- a/steering/TouchGFX/gui/include/gui/menuscreen_screen/MenuScreenPresenter.hpp
+++ b/steering/TouchGFX/gui/include/gui/menuscreen_screen/MenuScreenPresenter.hpp
@@ -3,12 +3,13 @@
 
 #include <gui/model/ModelListener.hpp>
 #include <mvp/Presenter.hpp>
+#include <gui/common/ListManager.hpp>
 
 using namespace touchgfx;
 
 class MenuScreenView;
 
-class MenuScreenPresenter : public touchgfx::Presenter, public ModelListener
+class MenuScreenPresenter : public touchgfx::Presenter, public ModelListener, public ListManager<Section>
 {
 public:
     MenuScreenPresenter(MenuScreenView& v);
@@ -32,24 +33,13 @@ public:
     void handleButtonUp() override;
     void handleButtonConfirm() override;
     void handleButtonBack() override;
-
-    static const uint8_t MAX_SECTIONS = 16;
 private:
     MenuScreenPresenter();
     
     MenuScreenView& view;
 
-    void adaptIndexes();
-    void updateSectionTilesInView();
-    void setSelected();
-
-    int currentIndex;
-    int firstTileIndex;
-    int lastTileIndex;
-
-    const uint8_t NUM_TILES_TO_SHOW = 5;
-    uint8_t nSections;
-    Section *sections[MAX_SECTIONS];
+    void updateItemTilesInView(Section *items[], uint8_t nItems) override;
+    void setSelected() override;
 };
 
 #endif // MENUSCREENPRESENTER_HPP

--- a/steering/TouchGFX/gui/include/gui/modulescreen_screen/ModuleScreenPresenter.hpp
+++ b/steering/TouchGFX/gui/include/gui/modulescreen_screen/ModuleScreenPresenter.hpp
@@ -3,12 +3,13 @@
 
 #include <gui/model/ModelListener.hpp>
 #include <mvp/Presenter.hpp>
+#include <gui/common/ListManager.hpp>
 
 using namespace touchgfx;
 
 class ModuleScreenView;
 
-class ModuleScreenPresenter : public touchgfx::Presenter, public ModelListener
+class ModuleScreenPresenter : public touchgfx::Presenter, public ModelListener, public ListManager<Measurement>
 {
 public:
     ModuleScreenPresenter(ModuleScreenView& v);
@@ -26,8 +27,7 @@ public:
     virtual void deactivate();
 
     virtual ~ModuleScreenPresenter() {}
-    static const uint8_t MAX_MEASUREMENTS = 64;
-    void setMeasurements(Measurement *measurements[], uint8_t nMeasurements);
+    void setMeasurements(Measurement *measurements[], uint8_t nMeasurements) override;
     void setModuleTitle(char const *name) override;
     void handleButtonDown() override;
     void handleButtonUp() override;
@@ -35,19 +35,12 @@ public:
 private:
     ModuleScreenPresenter();
 
+    int scrollAmount() override { return 2; }
+
     ModuleScreenView& view;
 
-    void adaptIndexes();
-    void updateMeasurementTilesInView();
+    void updateItemTilesInView(Measurement *items[], uint8_t nItems) override;
     void setSelected();
-
-    uint8_t currentIndex;
-    uint8_t firstTileIndex;
-    uint8_t lastTileIndex;
-
-    const uint8_t NUM_TILES_TO_SHOW = 10;
-    uint8_t nMeasurements;
-    Measurement *measurements[MAX_MEASUREMENTS];
 };
 
 #endif // MODULESCREENPRESENTER_HPP

--- a/steering/TouchGFX/gui/include/gui/sectionscreen_screen/SectionScreenPresenter.hpp
+++ b/steering/TouchGFX/gui/include/gui/sectionscreen_screen/SectionScreenPresenter.hpp
@@ -3,12 +3,13 @@
 
 #include <gui/model/ModelListener.hpp>
 #include <mvp/Presenter.hpp>
+#include <gui/common/ListManager.hpp>
 
 using namespace touchgfx;
 
 class SectionScreenView;
 
-class SectionScreenPresenter : public touchgfx::Presenter, public ModelListener
+class SectionScreenPresenter : public touchgfx::Presenter, public ModelListener, public ListManager<Module>
 {
 public:
     SectionScreenPresenter(SectionScreenView& v);
@@ -27,7 +28,6 @@ public:
 
     virtual ~SectionScreenPresenter() {}
 
-    static const uint8_t MAX_MODULES = 16;
     void setModules(Module *modules[], uint8_t nModules) override;
     void setSectionTitle(char const *name) override;
     void handleButtonDown() override;
@@ -39,17 +39,8 @@ private:
 
     SectionScreenView& view;
 
-    void adaptIndexes();
-    void updateModuleTilesInView();
-    void setSelected();
-
-    uint8_t currentIndex;
-    uint8_t firstTileIndex;
-    uint8_t lastTileIndex;
-
-    const uint8_t NUM_TILES_TO_SHOW = 5;
-    uint8_t nModules;
-    Module *modules[MAX_MODULES];
+    void updateItemTilesInView(Module *items[], uint8_t nItems) override;
+    void setSelected() override;
 };
 
 #endif // SECTIONSCREENPRESENTER_HPP

--- a/steering/TouchGFX/gui/src/menuscreen_screen/MenuScreenPresenter.cpp
+++ b/steering/TouchGFX/gui/src/menuscreen_screen/MenuScreenPresenter.cpp
@@ -5,7 +5,7 @@
 #include <cstring>
 
 MenuScreenPresenter::MenuScreenPresenter(MenuScreenView& v)
-    : view(v), currentIndex(0), firstTileIndex(0), lastTileIndex(4)
+    : ListManager(5), view(v)
 {
 
 }
@@ -22,70 +22,31 @@ void MenuScreenPresenter::deactivate()
 
 void MenuScreenPresenter::setSections(Section *sections[], uint8_t nSections)
 {
-    this->nSections = nSections;
-
-    for (int i = 0; i < nSections; ++i) {
-        this->sections[i] = sections[i];
-    }
-
-    currentIndex = 0; 
-    firstTileIndex = 0;
-   
-    lastTileIndex = static_cast<uint8_t>(
-        std::min(
-            static_cast<int>(nSections) - 1, 
-            static_cast<int>(NUM_TILES_TO_SHOW) - 1
-        )
-    );
-
-    updateSectionTilesInView();
-    setSelected();
+    ListManager<Section>::setItems(sections, nSections);
 }
 
 void MenuScreenPresenter::handleButtonDown()
 {
-    if (!nSections) return;
-
-    currentIndex = static_cast<uint8_t>(
-        std::min(
-            static_cast<int>(currentIndex) + 1,
-            static_cast<int>(nSections) - 1
-        )
-    );
-
-    adaptIndexes();
-    updateSectionTilesInView();
-    setSelected();
+    ListManager<Section>::handleButtonDown();
 }
 
 void MenuScreenPresenter::handleButtonUp()
 {
-    if (!nSections) return;
-
-    currentIndex = static_cast<uint8_t>(
-        std::max(
-            static_cast<int>(currentIndex) - 1,
-            0
-        )
-    );
-
-    adaptIndexes();
-    updateSectionTilesInView();
-    setSelected();
+    ListManager<Section>::handleButtonUp();
 }
 
 void MenuScreenPresenter::handleButtonConfirm()
 {
-    if (currentIndex < static_cast<uint8_t>(0) || currentIndex >= nSections) return;
+    if (currentIndex < static_cast<uint8_t>(0) || currentIndex >= nItems) return;
 
-    if (sections[currentIndex] == nullptr) return;
+    if (items[currentIndex] == nullptr) return;
 
-    if (strcmp(sections[currentIndex]->getName(), "Drive") == 0) {
+    if (strcmp(items[currentIndex]->getName(), "Drive") == 0) {
         view.gotoDriveScreen();
-    } else if (strcmp(sections[currentIndex]->getName(), "Start Up") == 0) {
+    } else if (strcmp(items[currentIndex]->getName(), "Start Up") == 0) {
         view.gotoStartUpScreen();
     } else {
-        model->setChosenSection(sections[currentIndex]->getName());
+        model->setChosenSection(items[currentIndex]->getName());
         view.gotoSectionScreen();
     }
 }
@@ -95,66 +56,9 @@ void MenuScreenPresenter::handleButtonBack()
     
 }
 
-void MenuScreenPresenter::adaptIndexes()
+void MenuScreenPresenter::updateItemTilesInView(Section *items[], uint8_t nItems)
 {
-    if (!nSections) {
-        firstTileIndex = static_cast<uint8_t>(0);
-        lastTileIndex = static_cast<uint8_t>(0);
-        return;
-    }
-
-    if (currentIndex < firstTileIndex) {
-        firstTileIndex = currentIndex;
-        lastTileIndex = static_cast<uint8_t>(
-            static_cast<int>(firstTileIndex) + static_cast<int>(NUM_TILES_TO_SHOW) - 1
-        );
-    } else if (currentIndex > lastTileIndex) {
-        firstTileIndex = static_cast<uint8_t>(
-            static_cast<int>(currentIndex) - static_cast<int>(NUM_TILES_TO_SHOW) - 1
-        );
-        lastTileIndex = currentIndex;
-    }
-
-    if (lastTileIndex >= nSections) {
-        lastTileIndex = static_cast<uint8_t>(nSections - 1);
-        firstTileIndex = static_cast<uint8_t>(
-            std::max(
-                0,
-                static_cast<int>(lastTileIndex) - static_cast<int>(NUM_TILES_TO_SHOW) - 1
-            )
-        );
-    }
-    if (firstTileIndex < static_cast<uint8_t>(0)) {
-        firstTileIndex = static_cast<uint8_t>(0);
-        lastTileIndex = static_cast<uint8_t>(
-            std::min(
-                static_cast<int>(nSections) - 1,
-                static_cast<int>(NUM_TILES_TO_SHOW) - 1
-            )
-        );
-    }
-}
-
-void MenuScreenPresenter::updateSectionTilesInView()
-{
-    uint8_t actualFirst = static_cast<uint8_t>(
-        std::max(0, static_cast<int>(firstTileIndex))
-    );
-    uint8_t actualLast = static_cast<uint8_t>(
-        std::min(
-            static_cast<int>(nSections) - 1,
-            static_cast<int>(lastTileIndex)
-        )
-    );
-
-    Section *arrayToPass[static_cast<size_t>(actualLast - actualFirst + 1)];
-    if (actualFirst <= actualLast && nSections > 0) {
-        for (uint8_t i = actualFirst; i <= actualLast; ++i) {
-            arrayToPass[i - actualFirst] = sections[i];
-        }
-    }
-
-    view.setSections(arrayToPass, static_cast<uint8_t>(actualLast - actualFirst + 1));
+    view.setSections(items, nItems);
 }
 
 void MenuScreenPresenter::setSelected()

--- a/steering/TouchGFX/gui/src/model/Model.cpp
+++ b/steering/TouchGFX/gui/src/model/Model.cpp
@@ -14,13 +14,13 @@ Model::Model() : modelListener(0), configuration(nullptr), chosenSection(""), ch
 
 void Model::initSections()
 {
-  Section *sections[SectionScreenPresenter::MAX_MODULES];
+  Section *sections[MenuScreenPresenter::MAX_ITEMS];
   uint8_t nSections = configuration->getNSections();
 
   Section *current = configuration->getFirstSection();
   uint8_t i = 0;
 
-  while (current && nSections < MenuScreenPresenter::MAX_SECTIONS) {
+  while (current && nSections < MenuScreenPresenter::MAX_ITEMS) {
     sections[i] = current;
 
     i++;
@@ -32,7 +32,7 @@ void Model::initSections()
 
 void Model::initSectionMenu()
 {  
-  Module *modules[SectionScreenPresenter::MAX_MODULES];
+  Module *modules[SectionScreenPresenter::MAX_ITEMS];
   uint8_t nModules = 0;
 
   Section *section = configuration->getSectionByName(chosenSection);
@@ -45,7 +45,7 @@ void Model::initSectionMenu()
   nModules = section->getNModules();
   uint8_t i = 0;
 
-  while (current && nModules < SectionScreenPresenter::MAX_MODULES) {
+  while (current && nModules < SectionScreenPresenter::MAX_ITEMS) {
     modules[i] = current;
 
     i++;
@@ -66,7 +66,7 @@ void Model::initSectionTitle()
 
 void Model::initModuleMenu()
 {  
-  Measurement *measurements[ModuleScreenPresenter::MAX_MEASUREMENTS];
+  Measurement *measurements[ModuleScreenPresenter::MAX_ITEMS];
   uint8_t nMeasurements = 0;
 
   Section *section = configuration->getSectionByName(chosenSection);
@@ -85,7 +85,7 @@ void Model::initModuleMenu()
   nMeasurements = module_->getNMeasurements();
   uint8_t i = 0;
 
-  while (current && nMeasurements < ModuleScreenPresenter::MAX_MEASUREMENTS) {
+  while (current && nMeasurements < ModuleScreenPresenter::MAX_ITEMS) {
     measurements[i] = current;
 
     i++;

--- a/steering/TouchGFX/gui/src/modulescreen_screen/ModuleScreenPresenter.cpp
+++ b/steering/TouchGFX/gui/src/modulescreen_screen/ModuleScreenPresenter.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 
 ModuleScreenPresenter::ModuleScreenPresenter(ModuleScreenView& v)
-    : view(v)
+    : ListManager(10), view(v)
 {
 
 }
@@ -22,24 +22,7 @@ void ModuleScreenPresenter::deactivate()
 
 void ModuleScreenPresenter::setMeasurements(Measurement *measurements[], uint8_t nMeasurements)
 {
-    this->nMeasurements = nMeasurements;
-
-    for (uint8_t i = 0; i < nMeasurements; ++i) {
-        this->measurements[i] = measurements[i];
-    }
-
-    currentIndex = static_cast<uint8_t>(0);
-    firstTileIndex = static_cast<uint8_t>(0);
-
-    lastTileIndex = static_cast<uint8_t>(
-        std::min(
-            static_cast<int>(nMeasurements) - 1,
-            static_cast<int>(NUM_TILES_TO_SHOW) - 1
-        )
-    );
-
-    updateMeasurementTilesInView();
-    setSelected();
+    ListManager<Measurement>::setItems(measurements, nMeasurements);
 }
 
 void ModuleScreenPresenter::setModuleTitle(char const *name)
@@ -49,34 +32,12 @@ void ModuleScreenPresenter::setModuleTitle(char const *name)
 
 void ModuleScreenPresenter::handleButtonDown()
 {
-    if (!nMeasurements) return;
-
-    currentIndex = static_cast<uint8_t>(
-        std::min(
-            static_cast<int>(currentIndex) + 2,
-            static_cast<int>(nMeasurements) - 1
-        )
-    );
-
-    adaptIndexes();
-    updateMeasurementTilesInView();
-    setSelected();
+    ListManager<Measurement>::handleButtonDown();
 }
 
 void ModuleScreenPresenter::handleButtonUp()
 {
-    if (!nMeasurements) return;
-
-    currentIndex = static_cast<uint8_t>(
-        std::max(
-            static_cast<int>(currentIndex) - 2,
-            0
-        )
-    );
-
-    adaptIndexes();
-    updateMeasurementTilesInView();
-    setSelected();
+    ListManager<Measurement>::handleButtonUp();
 }
 
 void ModuleScreenPresenter::handleButtonBack()
@@ -84,69 +45,12 @@ void ModuleScreenPresenter::handleButtonBack()
     
 }
 
-void ModuleScreenPresenter::adaptIndexes()
+void ModuleScreenPresenter::updateItemTilesInView(Measurement *items[], uint8_t nItems)
 {
-    if (!nMeasurements) {
-        firstTileIndex = static_cast<uint8_t>(0);
-        lastTileIndex = static_cast<uint8_t>(0);
-        return;
-    }
-
-    if (currentIndex < firstTileIndex) {
-        firstTileIndex = currentIndex;
-        lastTileIndex = static_cast<uint8_t>(
-            static_cast<int>(firstTileIndex) + static_cast<int>(NUM_TILES_TO_SHOW) - 1
-        );
-    } else if (currentIndex > lastTileIndex) {
-        firstTileIndex = static_cast<uint8_t>(
-            static_cast<int>(currentIndex) - (static_cast<int>(NUM_TILES_TO_SHOW) - 1)
-        );
-        lastTileIndex = currentIndex;
-    }
-
-    if (lastTileIndex >= nMeasurements) {
-        lastTileIndex = static_cast<uint8_t>(nMeasurements - 1);
-        firstTileIndex = static_cast<uint8_t>(
-            std::max(
-                0,
-                static_cast<int>(lastTileIndex) - (static_cast<int>(NUM_TILES_TO_SHOW) - 1)
-            )
-        );
-    }
-    if (firstTileIndex < static_cast<uint8_t>(0)) {
-        firstTileIndex = static_cast<uint8_t>(0);
-        lastTileIndex = static_cast<uint8_t>(
-            std::min(
-                static_cast<int>(nMeasurements) - 1,
-                static_cast<int>(NUM_TILES_TO_SHOW) - 1
-            )
-        );
-    }
-}
-
-void ModuleScreenPresenter::updateMeasurementTilesInView()
-{
-    uint8_t actualFirst = static_cast<uint8_t>(
-        std::max(0, static_cast<int>(firstTileIndex))
-    );
-    uint8_t actualLast = static_cast<uint8_t>(
-        std::min(
-            static_cast<int>(nMeasurements) - 1,
-            static_cast<int>(lastTileIndex)
-        )
-    );
-
-    Measurement *arrayToPass[static_cast<size_t>(actualLast - actualFirst + 1)];
-    if (actualFirst <= actualLast && nMeasurements > 0) {
-        for (uint8_t i = actualFirst; i <= actualLast; ++i) {
-            arrayToPass[i - actualFirst] = measurements[i];
-        }
-    }
-
-    view.setMeasurements(arrayToPass, static_cast<uint8_t>(actualLast - actualFirst + 1));
+    view.setMeasurements(items, nItems);
 }
 
 void ModuleScreenPresenter::setSelected()
 {
-    view.setSelected(static_cast<uint8_t>(currentIndex - firstTileIndex));
+    view.setSelected(currentIndex - firstTileIndex);
 }

--- a/steering/TouchGFX/gui/src/sectionscreen_screen/SectionScreenPresenter.cpp
+++ b/steering/TouchGFX/gui/src/sectionscreen_screen/SectionScreenPresenter.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 
 SectionScreenPresenter::SectionScreenPresenter(SectionScreenView& v)
-    : view(v)
+    : ListManager(5), view(v)
 {
 
 }
@@ -22,24 +22,7 @@ void SectionScreenPresenter::deactivate()
 
 void SectionScreenPresenter::setModules(Module *modules[], uint8_t nModules)
 {
-    this->nModules = nModules;
-
-    for (uint8_t i = 0; i < nModules; ++i) {
-        this->modules[i] = modules[i];
-    }
-
-    currentIndex = static_cast<uint8_t>(0);
-    firstTileIndex = static_cast<uint8_t>(0);
-
-    lastTileIndex = static_cast<uint8_t>(
-        std::min(
-            static_cast<int>(nModules) - 1,
-            static_cast<int>(NUM_TILES_TO_SHOW) - 1
-        )
-    );
-
-    updateModuleTilesInView();
-    setSelected();
+    ListManager<Module>::setItems(modules, nModules);
 }
 
 void SectionScreenPresenter::setSectionTitle(char const *name)
@@ -49,41 +32,21 @@ void SectionScreenPresenter::setSectionTitle(char const *name)
 
 void SectionScreenPresenter::handleButtonDown()
 {
-    if (!nModules) return;
-
-    currentIndex = static_cast<uint8_t>(
-        std::min(
-            static_cast<int>(currentIndex) + 1,
-            static_cast<int>(nModules) - 1
-        )
-    );
-    adaptIndexes();
-    updateModuleTilesInView();
-    setSelected();
+    ListManager<Module>::handleButtonUp();
 }
 
 void SectionScreenPresenter::handleButtonUp()
 {
-    if (!nModules) return;
-
-    currentIndex = static_cast<uint8_t>(
-        std::max(
-            static_cast<int>(currentIndex) - 1,
-            0
-        )
-    );
-    adaptIndexes();
-    updateModuleTilesInView();
-    setSelected();
+    ListManager<Module>::handleButtonUp();
 }
 
 void SectionScreenPresenter::handleButtonConfirm()
 {
-    if (currentIndex < static_cast<uint8_t>(0) || currentIndex >= nModules) return;
+    if (currentIndex < static_cast<uint8_t>(0) || currentIndex >= nItems) return;
 
-    if (modules[currentIndex] == nullptr) return;
+    if (items[currentIndex] == nullptr) return;
 
-    model->setChosenModule(modules[currentIndex]->getName());
+    model->setChosenModule(items[currentIndex]->getName());
     view.gotoModuleScreen();
 }
 
@@ -92,69 +55,12 @@ void SectionScreenPresenter::handleButtonBack()
     
 }
 
-void SectionScreenPresenter::adaptIndexes()
+void SectionScreenPresenter::updateItemTilesInView(Module *items[], uint8_t nItems)
 {
-    if (!nModules) {
-        firstTileIndex = static_cast<uint8_t>(0);
-        lastTileIndex = static_cast<uint8_t>(0);
-        return;
-    }
-
-    if (currentIndex < firstTileIndex) {
-        firstTileIndex = currentIndex;
-        lastTileIndex = static_cast<uint8_t>(
-            static_cast<int>(firstTileIndex) + static_cast<int>(NUM_TILES_TO_SHOW) - 1
-        );
-    } else if (currentIndex > lastTileIndex) {
-        firstTileIndex = static_cast<uint8_t>(
-            static_cast<int>(currentIndex) - (static_cast<int>(NUM_TILES_TO_SHOW) - 1)
-        );
-        lastTileIndex = currentIndex;
-    }
-
-    if (lastTileIndex >= nModules) {
-        lastTileIndex = static_cast<uint8_t>(nModules - 1);
-        firstTileIndex = static_cast<uint8_t>(
-            std::max(
-                0,
-                static_cast<int>(lastTileIndex) - (static_cast<int>(NUM_TILES_TO_SHOW) - 1)
-            )
-        );
-    }
-    if (firstTileIndex < static_cast<uint8_t>(0)) {
-        firstTileIndex = static_cast<uint8_t>(0);
-        lastTileIndex = static_cast<uint8_t>(
-            std::min(
-                static_cast<int>(nModules) - 1,
-                static_cast<int>(NUM_TILES_TO_SHOW) - 1
-            )
-        );
-    }
-}
-
-void SectionScreenPresenter::updateModuleTilesInView()
-{
-    uint8_t actualFirst = static_cast<uint8_t>(
-        std::max(0, static_cast<int>(firstTileIndex))
-    );
-    uint8_t actualLast = static_cast<uint8_t>(
-        std::min(
-            static_cast<int>(nModules) - 1,
-            static_cast<int>(lastTileIndex)
-        )
-    );
-
-    Module *arrayToPass[static_cast<size_t>(actualLast - actualFirst + 1)];
-    if (actualFirst <= actualLast && nModules > 0) {
-        for (uint8_t i = actualFirst; i <= actualLast; ++i) {
-            arrayToPass[i - actualFirst] = modules[i];
-        }
-    }
-
-    view.setModules(arrayToPass, static_cast<uint8_t>(actualLast - actualFirst + 1));
+    view.setModules(items, nItems);
 }
 
 void SectionScreenPresenter::setSelected()
 {
-    view.setSelected(static_cast<uint8_t>(currentIndex - firstTileIndex));
+    view.setSelected(currentIndex - firstTileIndex);
 }


### PR DESCRIPTION
The Presenters that control lists in the relative Views now inherit from `ListManager`, which contains all the logic previously implemented in every Presenter.